### PR TITLE
Remove unnecessary indices

### DIFF
--- a/client/index.rst
+++ b/client/index.rst
@@ -8,12 +8,3 @@ Contents:
 
    architecture
    satnogsclient
-
-
-Indices and tables
-==================
-
-* :ref:`genindex`
-* :ref:`modindex`
-* :ref:`search`
-


### PR DESCRIPTION
We have some unnecessary indices on client index documentation that create a wrong item on [contents](http://docs.satnogs.org/).