### PR TITLE
Adding vorbis-tools to dependencies

### DIFF
--- a/client/raspi2-install.rst
+++ b/client/raspi2-install.rst
@@ -22,7 +22,7 @@ Let's get some required packages out of the way first::
 
    sudo apt-get update
    sudo apt-get upgrade
-   sudo apt-get install -y python-pip python-dev supervisor cmake libusb-1.0-0-dev libhamlib-utils
+   sudo apt-get install -y python-pip python-dev supervisor cmake libusb-1.0-0-dev libhamlib-utils vorbis-tools
 
 --------------------
 OS optional packages


### PR DESCRIPTION
I missed vorbis-tools in the initial apt-get install line,
required for oggenc.  Fixed this in the doc.