### PR TITLE
easier udev setup for BBB

### DIFF
--- a/client/bbb-install.rst
+++ b/client/bbb-install.rst
@@ -60,11 +60,10 @@ Next, clone and build the rtl-sdr tools::
    git clone https://github.com/satnogs/rtl-sdr.git
    mkdir rtl-sdr/build
    cd rtl-sdr/build
-   cmake ../
+   cmake ../ -DINSTALL_UDEV_RULES=ON
    make
    sudo make install
    sudo ldconfig
-   sudo cp ../rtl-sdr.rules /etc/udev/rules.d
    sudo udevadm trigger
 
 At this point you should be able to run rtl_test with your dongle plugged in and it will be detected. Press CTRL-C to exit the test.


### PR DESCRIPTION
in PR #15 we setup the udev files with a cmake flag, removing a
step. This brings the BBB instructions up to sync with raspi